### PR TITLE
Fix rectangle selection and build warning.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -74,7 +74,11 @@ impl <'env> IntoJObject<'env> for Rectangle {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Pair<'env, K: IntoJObject<'env>, V: IntoJObject<'env>>(K, V, &'env std::marker::PhantomData<()>);
+pub struct Pair<'env, K: IntoJObject<'env>, V: IntoJObject<'env>>(
+	K,
+	V,
+	#[allow(dead_code)] &'env std::marker::PhantomData<()>,
+);
 impl <'env, K: IntoJObject<'env>, V: IntoJObject<'env>> Pair<'env, K, V> {
 	pub fn new(left: K, right: V) -> Self {
 		Self(left, right, &std::marker::PhantomData)

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -65,8 +65,8 @@ impl Rectangle {
 impl <'env> IntoJObject<'env> for Rectangle {
 	fn get_jobject(&self, env: &'env TabulaEnv) -> JResult<JObject<'env>> {
 		env.new_object("technology/tabula/Rectangle", "(FFFF)V", &[
-			JValue::from(self.left),
 			JValue::from(self.top),
+			JValue::from(self.left),
 			JValue::from(self.width),
 			JValue::from(self.height)
 		])


### PR DESCRIPTION
Thanks for your library. I noticed some code that I was using was getting data from the wrong region of a page. In referencing `technology.tabula.Rectangle` [1], it appears that the order of parameters differs from the arguments passed from `tabula::Rectangle::IntoJObject` [2].

[1] https://github.com/tabulapdf/tabula-java/blob/8bfa3ad23af34f757f72fe46584a34abfc022ed3/src/main/java/technology/tabula/Rectangle.java#L38 (top, left, width, height)
[2] https://github.com/sp1ritCS/tabula-rs/blob/7e99c590c9fba8fb34b2fd48b14781bd859a7cb8/src/objects.rs#L68-L71 (left, top, width, height)